### PR TITLE
Add monitoring service with dashboard and Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY pyproject.toml setup.cfg setup.py MANIFEST.in README.md ./
+COPY tvscreener ./tvscreener
+COPY monitor_app.py ./monitor_app.py
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --upgrade pip \
+    && pip install .
+
+RUN useradd --create-home --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app/data \
+    && chown -R appuser:appuser /app
+
+USER appuser
+
+EXPOSE 8000
+VOLUME ["/app/data"]
+
+ENTRYPOINT ["uvicorn", "monitor_app:app", "--host", "0.0.0.0", "--port", "8000"]
+
+HEALTHCHECK --interval=60s --timeout=5s --start-period=120s --retries=3 \
+  CMD curl -f http://127.0.0.1:8000/healthz || exit 1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include tvscreener/monitoring/templates *.html

--- a/README.md
+++ b/README.md
@@ -63,3 +63,63 @@ df = cs.get()
 
 For Options and Filters, please check the [notebooks](https://github.com/houseofai/tvscreener/tree/main/notebooks) for
 examples.
+## Monitoring Service & Dashboard
+
+The repository ships with a production-ready monitoring service that periodically pulls data from the TradingView stock
+screener, persists the snapshots to SQLite and exposes a real-time dashboard plus REST API. The service runs on top of
+FastAPI and can be launched directly or via Docker.
+
+### Running locally
+
+1. Install the project in editable mode:
+
+   ```bash
+   pip install -e .
+   ```
+
+2. Start the FastAPI application:
+
+   ```bash
+   uvicorn monitor_app:app --host 0.0.0.0 --port 8000
+   ```
+
+3. Open `http://localhost:8000/` to view the dashboard. Recent analyst rating changes are highlighted and clicking on a
+   row reveals the corresponding price history chart.
+
+Environment variables control the monitoring behaviour (defaults in parentheses):
+
+| Variable            | Description                                              |
+|---------------------|----------------------------------------------------------|
+| `INTERVAL_SECONDS`  | Polling interval in seconds (600).                        |
+| `RANGE_START`       | Starting index for the TradingView screener range (0).    |
+| `RANGE_END`         | End index (exclusive) for the screener range (150).       |
+| `DB_PATH`           | Path to the SQLite database (`/app/data/monitor.db`).     |
+| `MAX_RETRIES`       | Maximum retry attempts for failed fetches (3).            |
+| `RETRY_BACKOFF_SECONDS` | Backoff seconds added between retries (30).           |
+
+Snapshots are stored in the `snapshots` table, while analyst rating deltas are written to the `rating_changes` table.
+Whenever a change is detected the service logs it and the dashboard updates automatically.
+
+### REST API
+
+- `GET /api/rating_changes` – Paginated list of rating change events.
+- `GET /api/symbol/{symbol}/history` – Snapshot history and prices for a symbol.
+- `GET /healthz` – Health probe and latest run metadata.
+
+### Docker image
+
+Build and run the container for an out-of-the-box deployment:
+
+```bash
+docker build -t tvscreener-monitor .
+docker run -d \
+  --name tvscreener-monitor \
+  -p 8000:8000 \
+  -e INTERVAL_SECONDS=600 \
+  -e RANGE_END=500 \
+  -v $(pwd)/data:/app/data \
+  tvscreener-monitor
+```
+
+The container exposes port `8000` and stores SQLite data inside `/app/data`. Mounting the path as a volume keeps the data
+between restarts. The built-in health check pings `/healthz`, making it suitable for orchestration probes.

--- a/monitor_app.py
+++ b/monitor_app.py
@@ -1,0 +1,5 @@
+"""Entry point for running the monitoring FastAPI application."""
+
+from tvscreener.monitoring.app import app, create_app
+
+__all__ = ["app", "create_app"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tvscreener"
-version = "0.0.13"
+version = "0.1.0"
 description = "TradingView Screener API"
 readme = "README.md"
 authors = [
@@ -15,7 +15,12 @@ requires-python = ">=3.10"
 keywords = ["finance", "tradingview", "technical-analysis"]
 dependencies = [
     "pandas",
-    "requests>=2.27.1"
+    "requests>=2.27.1",
+    "jinja2",
+    "fastapi>=0.110.0",
+    "uvicorn[standard]",
+    "pydantic-settings>=2.0",
+    "python-dotenv"
 ]
 urls = {"Homepage" = "https://github.com/houseofai/tvscreener"}
 classifiers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,7 @@ tqdm
 setuptools
 pytest
 pytest-cov
+fastapi
+uvicorn[standard]
+pydantic-settings
+python-dotenv

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,17 @@ python_requires = >=3.10
 install_requires =
     pandas
     requests>=2.27.1
+    jinja2
+    fastapi>=0.110.0
+    uvicorn[standard]
+    pydantic-settings>=2.0
+    python-dotenv
+
+include_package_data = True
 
 [options.packages.find]
 include = tvscreener*
 exclude = notebooks, scripts, tests
+
+[options.package_data]
+tvscreener.monitoring = templates/*.html

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,0 +1,79 @@
+import sqlite3
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from tvscreener.monitoring.db import MonitoringDatabase
+from tvscreener.monitoring.models import RatingChange
+from tvscreener.monitoring.service import MonitorService
+from tvscreener.monitoring.settings import Settings
+
+
+@pytest.fixture()
+def temp_settings(tmp_path: Path) -> Settings:
+    return Settings(
+        interval_seconds=60,
+        range_start=0,
+        range_end=2,
+        db_path=str(tmp_path / "monitor.db"),
+        max_retries=0,
+    )
+
+
+@pytest.fixture()
+def database(temp_settings: Settings) -> MonitoringDatabase:
+    db = MonitoringDatabase(temp_settings.database_path)
+    db.initialize()
+    return db
+
+
+def test_process_dataframe_detects_rating_change(temp_settings: Settings, database: MonitoringDatabase):
+    service = MonitorService(temp_settings, database)
+
+    df_initial = pd.DataFrame([
+        {"Symbol": "AAPL", "AnalystRating": "Buy", "Price": 189.2},
+        {"Symbol": "MSFT", "AnalystRating": "Neutral", "Price": 327.5},
+    ])
+
+    changes, processed = service.process_dataframe(df_initial)
+    assert processed == 2
+    assert changes == []
+
+    df_updated = pd.DataFrame([
+        {"Symbol": "AAPL", "AnalystRating": "Sell", "Price": 185.0},
+        {"Symbol": "MSFT", "AnalystRating": "Neutral", "Price": 328.1},
+    ])
+
+    changes, processed = service.process_dataframe(df_updated)
+    assert processed == 2
+    assert len(changes) == 1
+    change: RatingChange = changes[0]
+    assert change.symbol == "AAPL"
+    assert change.old_rating == "Buy"
+    assert change.new_rating == "Sell"
+    assert pytest.approx(change.price_before or 0) == 189.2
+    assert pytest.approx(change.price_after or 0) == 185.0
+
+    total, rows = database.fetch_rating_changes(limit=10)
+    assert total == 1
+    assert rows[0]["symbol"] == "AAPL"
+
+
+def test_process_dataframe_handles_missing_values(temp_settings: Settings, database: MonitoringDatabase):
+    service = MonitorService(temp_settings, database)
+    df = pd.DataFrame([
+        {"Symbol": "TSLA", "AnalystRating": None, "Price": float("nan")},
+    ])
+
+    changes, processed = service.process_dataframe(df)
+    assert processed == 1
+    assert changes == []
+
+    with database.connect() as conn:
+        row = conn.execute(
+            "SELECT analyst_rating, price FROM snapshots WHERE symbol = ?",
+            ("TSLA",),
+        ).fetchone()
+    assert row["analyst_rating"] is None
+    assert row["price"] is None

--- a/tvscreener/__init__.py
+++ b/tvscreener/__init__.py
@@ -2,13 +2,36 @@ from .core.base import Screener, ScreenerDataFrame
 from .core.crypto import CryptoScreener
 from .core.forex import ForexScreener
 from .core.stock import StockScreener
-from .field import *
-from .filter import Filter
-from .util import *
+from .exceptions import MalformedRequestException
+from .field import Country, Exchange, Field, Industry, Market, Sector, TimeInterval
+from .field.crypto import CryptoField
+from .field.forex import ForexField
+from .field.stock import StockField
+from .filter import ExtraFilter, Filter, FilterOperator
+from .util import get_columns_to_request, get_recommendation, millify
 
-__version__ = "0.0.13"
+__version__ = "0.1.0"
 __all__ = [
-    "Screener", "ScreenerDataFrame",
-    "StockScreener", "ForexScreener", "CryptoScreener",
-    "Field", "Filter", "Market", "Exchange", "Country", "Sector", "Industry", "TimeInterval",
+    "Screener",
+    "ScreenerDataFrame",
+    "StockScreener",
+    "ForexScreener",
+    "CryptoScreener",
+    "Field",
+    "StockField",
+    "ForexField",
+    "CryptoField",
+    "Filter",
+    "FilterOperator",
+    "ExtraFilter",
+    "Market",
+    "Exchange",
+    "Country",
+    "Sector",
+    "Industry",
+    "TimeInterval",
+    "MalformedRequestException",
+    "get_columns_to_request",
+    "get_recommendation",
+    "millify",
 ]

--- a/tvscreener/monitoring/__init__.py
+++ b/tvscreener/monitoring/__init__.py
@@ -1,0 +1,16 @@
+"""Monitoring service for periodic stock data collection."""
+
+from .settings import Settings
+from .db import MonitoringDatabase
+from .models import MonitorState, RatingChange
+from .service import MonitorService
+from .app import create_app
+
+__all__ = [
+    "Settings",
+    "MonitoringDatabase",
+    "MonitorService",
+    "MonitorState",
+    "RatingChange",
+    "create_app",
+]

--- a/tvscreener/monitoring/app.py
+++ b/tvscreener/monitoring/app.py
@@ -1,0 +1,158 @@
+"""FastAPI application exposing the monitoring service."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import logging.config
+from contextlib import asynccontextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+from fastapi import Depends, FastAPI, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from .db import MonitoringDatabase
+from .service import MonitorService
+from .settings import Settings
+
+
+def configure_logging(settings: Settings) -> None:
+    """Configure application logging."""
+
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "formatters": {
+                "default": {
+                    "format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+                }
+            },
+            "handlers": {
+                "console": {
+                    "class": "logging.StreamHandler",
+                    "formatter": "default",
+                    "level": settings.log_level_upper(),
+                }
+            },
+            "root": {
+                "handlers": ["console"],
+                "level": settings.log_level_upper(),
+            },
+        }
+    )
+
+
+def create_app(settings: Optional[Settings] = None) -> FastAPI:
+    """Create and configure the FastAPI application."""
+
+    settings = settings or Settings()
+    configure_logging(settings)
+
+    database = MonitoringDatabase(settings.database_path)
+    database.initialize()
+    service = MonitorService(settings, database)
+
+    templates = Jinja2Templates(directory=str(Path(__file__).with_name("templates")))
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        service.start()
+        try:
+            yield
+        finally:
+            await service.stop()
+
+    app = FastAPI(title="TVScreener Monitoring Service", lifespan=lifespan)
+    app.state.settings = settings
+    app.state.database = database
+    app.state.service = service
+    app.state.templates = templates
+
+    def get_settings(request: Request) -> Settings:
+        return request.app.state.settings
+
+    def get_database(request: Request) -> MonitoringDatabase:
+        return request.app.state.database
+
+    def get_service(request: Request) -> MonitorService:
+        return request.app.state.service
+
+    def get_templates(request: Request) -> Jinja2Templates:
+        return request.app.state.templates
+
+    @app.get("/", response_class=HTMLResponse)
+    async def index(
+        request: Request,
+        service: MonitorService = Depends(get_service),
+        templates: Jinja2Templates = Depends(get_templates),
+        settings: Settings = Depends(get_settings),
+    ) -> HTMLResponse:
+        state_dict = service.state.to_dict()
+        context = {
+            "request": request,
+            "state": state_dict,
+            "settings": settings,
+        }
+        return templates.TemplateResponse("index.html", context)
+
+    @app.get("/api/rating_changes")
+    async def rating_changes(
+        limit: int = Query(50, ge=1, le=500),
+        offset: int = Query(0, ge=0),
+        database: MonitoringDatabase = Depends(get_database),
+    ) -> dict[str, Any]:
+        total, rows = await asyncio.to_thread(database.fetch_rating_changes, limit, offset)
+        return {"total": total, "items": rows, "limit": limit, "offset": offset}
+
+    @app.get("/api/symbol/{symbol}/history")
+    async def symbol_history(
+        symbol: str,
+        limit: int = Query(200, ge=1, le=2000),
+        start: Optional[str] = Query(None, description="ISO formatted start timestamp"),
+        end: Optional[str] = Query(None, description="ISO formatted end timestamp"),
+        database: MonitoringDatabase = Depends(get_database),
+    ) -> dict[str, Any]:
+        start_iso = _validate_isoformat(start, "start") if start else None
+        end_iso = _validate_isoformat(end, "end") if end else None
+        rows = await asyncio.to_thread(
+            database.fetch_symbol_history, symbol, limit, start_iso, end_iso
+        )
+        return {"symbol": symbol, "items": rows, "limit": limit}
+
+    @app.get("/healthz")
+    async def healthz(
+        service: MonitorService = Depends(get_service),
+        settings: Settings = Depends(get_settings),
+        database: MonitoringDatabase = Depends(get_database),
+    ) -> dict[str, Any]:
+        state_dict = service.state.to_dict()
+        latest_snapshot = await asyncio.to_thread(database.get_most_recent_snapshot_time)
+        status = "ok" if state_dict["last_error"] is None else "degraded"
+        return {
+            "status": status,
+            "is_running": service.is_running,
+            "interval_seconds": settings.interval_seconds,
+            "range": {"start": settings.range_start, "end": settings.range_end},
+            "state": state_dict,
+            "latest_snapshot": latest_snapshot,
+        }
+
+    return app
+
+
+def _validate_isoformat(value: str, field_name: str) -> str:
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:  # pylint: disable=raise-missing-from
+        raise HTTPException(status_code=400, detail=f"Invalid {field_name} value")
+    return dt.isoformat()
+
+
+app = create_app()
+
+
+__all__ = ["create_app", "app"]

--- a/tvscreener/monitoring/db.py
+++ b/tvscreener/monitoring/db.py
@@ -1,0 +1,228 @@
+"""SQLite persistence for the monitoring service."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+from .models import RatingChange
+
+
+def _json_default(value: Any) -> Any:
+    """Convert non-serialisable objects to JSON friendly representations."""
+
+    if isinstance(value, (datetime,)):
+        return value.isoformat()
+    if hasattr(value, "item"):
+        return value.item()
+    return str(value)
+
+
+class MonitoringDatabase:
+    """Wrapper around SQLite operations used by the monitoring service."""
+
+    def __init__(self, path: Path | str) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def initialize(self) -> None:
+        """Create the necessary tables if they do not already exist."""
+
+        with self.connect() as conn:
+            conn.executescript(
+                """
+                PRAGMA journal_mode=WAL;
+                CREATE TABLE IF NOT EXISTS snapshots (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    symbol TEXT NOT NULL,
+                    retrieved_at TEXT NOT NULL,
+                    analyst_rating TEXT,
+                    price REAL,
+                    raw_json TEXT,
+                    UNIQUE(symbol, retrieved_at)
+                );
+                CREATE TABLE IF NOT EXISTS rating_changes (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    symbol TEXT NOT NULL,
+                    changed_at TEXT NOT NULL,
+                    old_rating TEXT,
+                    new_rating TEXT,
+                    price_before REAL,
+                    price_after REAL,
+                    snapshot_rowid INTEGER,
+                    FOREIGN KEY(snapshot_rowid) REFERENCES snapshots(id) ON DELETE CASCADE
+                );
+                CREATE INDEX IF NOT EXISTS idx_snapshots_symbol_time ON snapshots(symbol, retrieved_at);
+                CREATE INDEX IF NOT EXISTS idx_rating_changes_symbol_time ON rating_changes(symbol, changed_at);
+                """
+            )
+
+    @contextmanager
+    def connect(self) -> Iterator[sqlite3.Connection]:
+        """Context manager yielding a SQLite connection with sane defaults."""
+
+        conn = sqlite3.connect(self.path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON;")
+        try:
+            yield conn
+            conn.commit()
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _serialize_row(record: Dict[str, Any]) -> str:
+        return json.dumps(record, default=_json_default)
+
+    def get_last_snapshot(self, conn: sqlite3.Connection, symbol: str) -> Optional[sqlite3.Row]:
+        """Return the most recent snapshot for the given symbol."""
+
+        cursor = conn.execute(
+            """
+            SELECT id, analyst_rating, price, retrieved_at
+            FROM snapshots
+            WHERE symbol = ?
+            ORDER BY retrieved_at DESC
+            LIMIT 1
+            """,
+            (symbol,),
+        )
+        return cursor.fetchone()
+
+    def insert_snapshot(
+        self,
+        conn: sqlite3.Connection,
+        symbol: str,
+        retrieved_at: str,
+        analyst_rating: Optional[str],
+        price: Optional[float],
+        raw_record: Dict[str, Any],
+    ) -> int:
+        """Insert a new snapshot row and return the SQLite rowid."""
+
+        cursor = conn.execute(
+            """
+            INSERT INTO snapshots(symbol, retrieved_at, analyst_rating, price, raw_json)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(symbol, retrieved_at) DO UPDATE SET
+                analyst_rating=excluded.analyst_rating,
+                price=excluded.price,
+                raw_json=excluded.raw_json
+            """,
+            (
+                symbol,
+                retrieved_at,
+                analyst_rating,
+                price,
+                self._serialize_row(raw_record),
+            ),
+        )
+        snapshot_id = cursor.lastrowid
+        if not snapshot_id:
+            snapshot_id = conn.execute(
+                "SELECT id FROM snapshots WHERE symbol = ? AND retrieved_at = ?",
+                (symbol, retrieved_at),
+            ).fetchone()[0]
+        return snapshot_id
+
+    def insert_rating_change(
+        self,
+        conn: sqlite3.Connection,
+        symbol: str,
+        changed_at: datetime,
+        old_rating: Optional[str],
+        new_rating: Optional[str],
+        price_before: Optional[float],
+        price_after: Optional[float],
+        snapshot_rowid: Optional[int],
+    ) -> RatingChange:
+        """Persist a rating change event and return the created model."""
+
+        cursor = conn.execute(
+            """
+            INSERT INTO rating_changes(symbol, changed_at, old_rating, new_rating, price_before, price_after, snapshot_rowid)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                symbol,
+                changed_at.isoformat(),
+                old_rating,
+                new_rating,
+                price_before,
+                price_after,
+                snapshot_rowid,
+            ),
+        )
+        return RatingChange(
+            id=cursor.lastrowid,
+            symbol=symbol,
+            changed_at=changed_at,
+            old_rating=old_rating,
+            new_rating=new_rating,
+            price_before=price_before,
+            price_after=price_after,
+            snapshot_rowid=snapshot_rowid,
+        )
+
+    def fetch_rating_changes(self, limit: int, offset: int = 0) -> Tuple[int, List[dict[str, Any]]]:
+        """Return total count and a page of rating change rows."""
+
+        with self.connect() as conn:
+            total = conn.execute("SELECT COUNT(*) FROM rating_changes").fetchone()[0]
+            cursor = conn.execute(
+                """
+                SELECT id, symbol, changed_at, old_rating, new_rating, price_before, price_after, snapshot_rowid
+                FROM rating_changes
+                ORDER BY changed_at DESC
+                LIMIT ? OFFSET ?
+                """,
+                (limit, offset),
+            )
+            rows = [dict(row) for row in cursor.fetchall()]
+        return total, rows
+
+    def fetch_symbol_history(
+        self,
+        symbol: str,
+        limit: int,
+        start: Optional[str] = None,
+        end: Optional[str] = None,
+    ) -> List[dict[str, Any]]:
+        """Return historical snapshots for a specific symbol."""
+
+        query = [
+            "SELECT symbol, retrieved_at, analyst_rating, price",
+            "FROM snapshots",
+            "WHERE symbol = ?",
+        ]
+        params: List[Any] = [symbol]
+        if start:
+            query.append("AND retrieved_at >= ?")
+            params.append(start)
+        if end:
+            query.append("AND retrieved_at <= ?")
+            params.append(end)
+        query.append("ORDER BY retrieved_at DESC LIMIT ?")
+        params.append(limit)
+        statement = " ".join(query)
+        with self.connect() as conn:
+            cursor = conn.execute(statement, params)
+            rows = [dict(row) for row in cursor.fetchall()]
+        rows.reverse()
+        return rows
+
+    def get_most_recent_snapshot_time(self) -> Optional[str]:
+        """Return the timestamp of the latest snapshot across all symbols."""
+
+        with self.connect() as conn:
+            row = conn.execute(
+                "SELECT retrieved_at FROM snapshots ORDER BY retrieved_at DESC LIMIT 1"
+            ).fetchone()
+            return row[0] if row else None
+
+
+__all__ = ["MonitoringDatabase"]

--- a/tvscreener/monitoring/models.py
+++ b/tvscreener/monitoring/models.py
@@ -1,0 +1,55 @@
+"""Data models used by the monitoring service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from datetime import datetime
+from typing import Any, List, Optional
+
+
+@dataclass
+class RatingChange:
+    """Represents a change in the analyst rating for a stock symbol."""
+
+    symbol: str
+    changed_at: datetime
+    old_rating: Optional[str]
+    new_rating: Optional[str]
+    price_before: Optional[float]
+    price_after: Optional[float]
+    snapshot_rowid: Optional[int]
+    id: Optional[int] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON serialisable representation of the rating change."""
+
+        data = asdict(self)
+        data["changed_at"] = self.changed_at.isoformat()
+        return data
+
+
+@dataclass
+class MonitorState:
+    """Holds runtime metadata about the monitoring loop."""
+
+    last_run: Optional[datetime] = None
+    last_success: Optional[datetime] = None
+    last_error: Optional[str] = None
+    total_snapshots: int = 0
+    total_rating_changes: int = 0
+    last_changes: List[RatingChange] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a serialisable version of the state for the API/UI."""
+
+        return {
+            "last_run": self.last_run.isoformat() if self.last_run else None,
+            "last_success": self.last_success.isoformat() if self.last_success else None,
+            "last_error": self.last_error,
+            "total_snapshots": self.total_snapshots,
+            "total_rating_changes": self.total_rating_changes,
+            "last_changes": [change.to_dict() for change in self.last_changes],
+        }
+
+
+__all__ = ["RatingChange", "MonitorState"]

--- a/tvscreener/monitoring/service.py
+++ b/tvscreener/monitoring/service.py
@@ -1,0 +1,242 @@
+"""Background monitoring service that polls TradingView data."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+import pandas as pd
+import tvscreener as tvs
+
+from .db import MonitoringDatabase
+from .models import MonitorState, RatingChange
+from .settings import Settings
+
+
+LOGGER = logging.getLogger("tvscreener.monitoring")
+
+
+class MonitorService:
+    """Runs the periodic monitoring workflow in the background."""
+
+    def __init__(self, settings: Settings, database: MonitoringDatabase) -> None:
+        self.settings = settings
+        self.database = database
+        self.state = MonitorState()
+        self._task: Optional[asyncio.Task[None]] = None
+        self._stop_event: Optional[asyncio.Event] = None
+
+    # ---------------------------------------------------------------------
+    # Lifecycle management
+    # ---------------------------------------------------------------------
+    def start(self) -> None:
+        """Start the monitoring loop if it is not already running."""
+
+        if self._task and not self._task.done():
+            return
+
+        self._stop_event = asyncio.Event()
+        self._task = asyncio.create_task(self._run_loop(), name="tvscreener-monitor")
+        LOGGER.info(
+            "Monitoring service started with interval=%ss range=(%s, %s)",
+            self.settings.interval_seconds,
+            self.settings.range_start,
+            self.settings.range_end,
+        )
+
+    async def stop(self) -> None:
+        """Stop the monitoring loop and wait for completion."""
+
+        if self._task is None:
+            return
+
+        if self._stop_event:
+            self._stop_event.set()
+
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self._task = None
+            self._stop_event = None
+            LOGGER.info("Monitoring service stopped")
+
+    @property
+    def is_running(self) -> bool:
+        return bool(self._task and not self._task.done())
+
+    async def trigger_once(self) -> List[RatingChange]:
+        """Run the monitoring cycle a single time and return detected changes."""
+
+        return await self._run_cycle()
+
+    # ------------------------------------------------------------------
+    # Core loop
+    # ------------------------------------------------------------------
+    async def _run_loop(self) -> None:
+        assert self._stop_event is not None
+        while not self._stop_event.is_set():
+            await self._run_cycle()
+            try:
+                await asyncio.wait_for(
+                    self._stop_event.wait(), timeout=self.settings.interval_seconds
+                )
+            except asyncio.TimeoutError:
+                continue
+
+    async def _run_cycle(self) -> List[RatingChange]:
+        """Execute a full monitoring cycle."""
+
+        now = datetime.now(timezone.utc)
+        self.state.last_run = now
+        try:
+            dataframe = await self._fetch_with_retries()
+            changes, processed = await asyncio.to_thread(self.process_dataframe, dataframe)
+            self.state.total_snapshots += processed
+            self.state.total_rating_changes += len(changes)
+            self.state.last_changes = changes
+            self.state.last_success = now
+            self.state.last_error = None
+            for change in changes:
+                LOGGER.info(
+                    "Analyst rating changed for %s: %s -> %s (price %s -> %s)",
+                    change.symbol,
+                    change.old_rating,
+                    change.new_rating,
+                    change.price_before,
+                    change.price_after,
+                )
+            return changes
+        except Exception as exc:  # pylint: disable=broad-except
+            self.state.last_error = str(exc)
+            LOGGER.exception("Monitoring cycle failed: %s", exc)
+            return []
+
+    async def _fetch_with_retries(self) -> pd.DataFrame:
+        """Fetch data from TradingView with retry handling."""
+
+        attempt = 0
+        delay = self.settings.retry_backoff_seconds
+        last_exc: Optional[Exception] = None
+        while attempt <= self.settings.max_retries:
+            try:
+                return await asyncio.to_thread(self._fetch_dataframe)
+            except Exception as exc:  # pylint: disable=broad-except
+                last_exc = exc
+                attempt += 1
+                if attempt > self.settings.max_retries:
+                    break
+                LOGGER.warning(
+                    "Fetch attempt %s failed: %s. Retrying in %ss", attempt, exc, delay
+                )
+                await asyncio.sleep(delay)
+                delay += self.settings.retry_backoff_seconds
+        assert last_exc is not None
+        raise last_exc
+
+    def _fetch_dataframe(self) -> pd.DataFrame:
+        """Blocking call that retrieves the dataframe from TradingView."""
+
+        screener = tvs.StockScreener()
+        start, end = self.settings.as_range()
+        screener.set_range(start, end)
+        return screener.get()
+
+    # ------------------------------------------------------------------
+    # Data processing helpers
+    # ------------------------------------------------------------------
+    def process_dataframe(self, dataframe: pd.DataFrame) -> Tuple[List[RatingChange], int]:
+        """Persist the dataframe and detect analyst rating changes."""
+
+        if dataframe is None or dataframe.empty:
+            return [], 0
+
+        retrieved_dt = datetime.now(timezone.utc)
+        retrieved_at = retrieved_dt.isoformat()
+
+        records = dataframe.to_dict(orient="records")
+        changes: List[RatingChange] = []
+        processed = 0
+        with self.database.connect() as conn:
+            for record in records:
+                symbol = self._extract_symbol(record)
+                if not symbol:
+                    continue
+                rating = self._extract_rating(record)
+                price = self._extract_price(record)
+                clean_record = self._sanitize_record(record)
+                previous = self.database.get_last_snapshot(conn, symbol)
+                snapshot_rowid = self.database.insert_snapshot(
+                    conn,
+                    symbol,
+                    retrieved_at,
+                    rating,
+                    price,
+                    clean_record,
+                )
+                processed += 1
+                if previous and previous["analyst_rating"] != rating:
+                    change = self.database.insert_rating_change(
+                        conn,
+                        symbol,
+                        retrieved_dt,
+                        previous["analyst_rating"],
+                        rating,
+                        previous["price"],
+                        price,
+                        snapshot_rowid,
+                    )
+                    changes.append(change)
+        return changes, processed
+
+    @staticmethod
+    def _sanitize_record(record: Dict[str, Any]) -> Dict[str, Any]:
+        clean: Dict[str, Any] = {}
+        for key, value in record.items():
+            if isinstance(value, datetime):
+                clean[key] = value.isoformat()
+            elif pd.isna(value):  # type: ignore[arg-type]
+                clean[key] = None
+            elif hasattr(value, "item"):
+                clean[key] = value.item()
+            else:
+                clean[key] = value
+        return clean
+
+    @staticmethod
+    def _extract_symbol(record: Dict[str, Any]) -> Optional[str]:
+        value = MonitorService._get_value_case_insensitive(record, "symbol")
+        if value is None:
+            return None
+        return str(value)
+
+    @staticmethod
+    def _extract_rating(record: Dict[str, Any]) -> Optional[str]:
+        value = MonitorService._get_value_case_insensitive(record, "AnalystRating")
+        if value is None:
+            return None
+        return str(value)
+
+    @staticmethod
+    def _extract_price(record: Dict[str, Any]) -> Optional[float]:
+        value = MonitorService._get_value_case_insensitive(record, "Price")
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _get_value_case_insensitive(record: Dict[str, Any], key: str) -> Optional[Any]:
+        lower_key = key.lower()
+        for item_key, item_value in record.items():
+            if item_key == key or item_key.lower() == lower_key:
+                return item_value
+        return None
+
+
+__all__ = ["MonitorService"]

--- a/tvscreener/monitoring/settings.py
+++ b/tvscreener/monitoring/settings.py
@@ -1,0 +1,76 @@
+"""Configuration handling for the monitoring service."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+from pydantic import Field, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Runtime configuration for the monitoring service."""
+
+    interval_seconds: int = Field(
+        600,
+        ge=60,
+        description="Interval in seconds between two data fetch cycles.",
+    )
+    range_start: int = Field(
+        0,
+        ge=0,
+        description="Start index for the TradingView screener range.",
+    )
+    range_end: int = Field(
+        150,
+        gt=0,
+        description="End index (exclusive) for the TradingView screener range.",
+    )
+    db_path: str = Field(
+        "/app/data/monitor.db",
+        description="Path to the SQLite database used to persist snapshots.",
+    )
+    log_level: str = Field(
+        "INFO",
+        description="Logging level for the monitoring service.",
+    )
+    max_retries: int = Field(
+        3,
+        ge=0,
+        description="Maximum number of retries for failed data fetch attempts.",
+    )
+    retry_backoff_seconds: int = Field(
+        30,
+        ge=0,
+        description="Base backoff in seconds between retry attempts.",
+    )
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+
+    @model_validator(mode="after")
+    def _validate_range(cls, values: "Settings") -> "Settings":  # type: ignore[override]
+        if values.range_end <= values.range_start:
+            raise ValueError("range_end must be greater than range_start")
+        return values
+
+    @property
+    def database_path(self) -> Path:
+        """Return the expanded database path ensuring the parent directory exists."""
+
+        path = Path(self.db_path).expanduser()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def as_range(self) -> Tuple[int, int]:
+        """Return the configured TradingView range as a tuple."""
+
+        return self.range_start, self.range_end
+
+    def log_level_upper(self) -> str:
+        """Return the logging level in upper case for logging configuration."""
+
+        return self.log_level.upper()
+
+
+__all__ = ["Settings"]

--- a/tvscreener/monitoring/templates/index.html
+++ b/tvscreener/monitoring/templates/index.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>TVScreener Monitoring Dashboard</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-w6VYj1WFJsbgx5caX5/C/PObbIVdQydb9h9NP7VDaRao7IhiHBpjz2uVH54camz1" crossorigin="anonymous"></script>
+    <style>
+        :root {
+            color-scheme: light dark;
+        }
+        body {
+            font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            margin: 0;
+            background: #0f172a;
+            color: #e2e8f0;
+        }
+        main {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 2rem 1rem 4rem;
+        }
+        h1 {
+            font-size: 2rem;
+            margin-bottom: 1rem;
+        }
+        .meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+            margin-bottom: 2rem;
+        }
+        .card {
+            background: rgba(15, 23, 42, 0.65);
+            border: 1px solid rgba(148, 163, 184, 0.2);
+            border-radius: 16px;
+            padding: 1.5rem;
+            box-shadow: 0 20px 40px rgba(15, 23, 42, 0.45);
+            backdrop-filter: blur(16px);
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        th, td {
+            padding: 0.75rem 1rem;
+            text-align: left;
+            border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+        }
+        th {
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: #94a3b8;
+        }
+        tr:hover {
+            background: rgba(30, 41, 59, 0.6);
+            cursor: pointer;
+        }
+        .status {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4rem;
+            padding: 0.25rem 0.75rem;
+            border-radius: 999px;
+            font-weight: 600;
+        }
+        .status.ok {
+            background: rgba(34, 197, 94, 0.15);
+            color: #4ade80;
+        }
+        .status.degraded {
+            background: rgba(249, 115, 22, 0.15);
+            color: #fb923c;
+        }
+        .chart-container {
+            position: relative;
+            height: 360px;
+        }
+        .muted {
+            color: #94a3b8;
+        }
+        @media (max-width: 768px) {
+            .meta {
+                flex-direction: column;
+            }
+            th, td {
+                padding: 0.5rem 0.75rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <header>
+            <h1>TVScreener Monitoring Dashboard</h1>
+            <p class="muted">Tracking analyst rating changes for the top {{ settings.range_end - settings.range_start }} instruments every {{ settings.interval_seconds // 60 }} minutes.</p>
+        </header>
+        <section class="meta">
+            <div class="card">
+                <strong>Status</strong>
+                <div id="statusBadge" class="status">Loading…</div>
+                <p class="muted">Last cycle: <span id="lastRun">—</span></p>
+            </div>
+            <div class="card">
+                <strong>Snapshots</strong>
+                <p class="muted"><span id="totalSnapshots">0</span> total | <span id="totalChanges">0</span> rating changes</p>
+                <p class="muted">Latest snapshot: <span id="latestSnapshot">—</span></p>
+            </div>
+        </section>
+
+        <section class="card" style="margin-bottom:2rem;">
+            <h2 style="margin-top:0">Recent Analyst Rating Changes</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Symbol</th>
+                        <th>Changed At</th>
+                        <th>Old Rating</th>
+                        <th>New Rating</th>
+                        <th>Price Before</th>
+                        <th>Price After</th>
+                    </tr>
+                </thead>
+                <tbody id="changesBody">
+                    <tr><td colspan="6" class="muted">Loading…</td></tr>
+                </tbody>
+            </table>
+        </section>
+
+        <section class="card">
+            <h2 style="margin-top:0">Price History</h2>
+            <p class="muted" id="chartCaption">Select a row above to load price history.</p>
+            <div class="chart-container">
+                <canvas id="historyChart"></canvas>
+            </div>
+        </section>
+    </main>
+
+    <script>
+        const statusBadge = document.getElementById('statusBadge');
+        const lastRunEl = document.getElementById('lastRun');
+        const totalSnapshotsEl = document.getElementById('totalSnapshots');
+        const totalChangesEl = document.getElementById('totalChanges');
+        const latestSnapshotEl = document.getElementById('latestSnapshot');
+        const changesBody = document.getElementById('changesBody');
+        const chartCaption = document.getElementById('chartCaption');
+        const chartCtx = document.getElementById('historyChart');
+
+        let historyChart = null;
+
+        function formatDate(value) {
+            if (!value) return '—';
+            const date = new Date(value);
+            return date.toLocaleString();
+        }
+
+        function setStatus(status, lastRun) {
+            statusBadge.className = `status ${status}`;
+            statusBadge.textContent = status === 'ok' ? 'Running' : 'Degraded';
+            lastRunEl.textContent = formatDate(lastRun);
+        }
+
+        async function refreshStatus() {
+            const response = await fetch('/healthz');
+            const data = await response.json();
+            setStatus(data.status, data.state.last_run);
+            totalSnapshotsEl.textContent = data.state.total_snapshots;
+            totalChangesEl.textContent = data.state.total_rating_changes;
+            latestSnapshotEl.textContent = formatDate(data.latest_snapshot);
+        }
+
+        function renderChanges(items) {
+            if (!items.length) {
+                changesBody.innerHTML = '<tr><td colspan="6" class="muted">No rating changes recorded yet.</td></tr>';
+                return;
+            }
+            changesBody.innerHTML = '';
+            for (const item of items) {
+                const tr = document.createElement('tr');
+                tr.dataset.symbol = item.symbol;
+                tr.innerHTML = `
+                    <td>${item.symbol}</td>
+                    <td>${formatDate(item.changed_at)}</td>
+                    <td>${item.old_rating ?? '—'}</td>
+                    <td>${item.new_rating ?? '—'}</td>
+                    <td>${item.price_before ?? '—'}</td>
+                    <td>${item.price_after ?? '—'}</td>
+                `;
+                tr.addEventListener('click', () => loadHistory(item.symbol));
+                changesBody.appendChild(tr);
+            }
+        }
+
+        async function refreshChanges() {
+            const response = await fetch('/api/rating_changes?limit=100');
+            const data = await response.json();
+            renderChanges(data.items);
+        }
+
+        async function loadHistory(symbol) {
+            chartCaption.textContent = `Loading price history for ${symbol}…`;
+            const response = await fetch(`/api/symbol/${encodeURIComponent(symbol)}/history?limit=200`);
+            const data = await response.json();
+            const labels = data.items.map(item => formatDate(item.retrieved_at));
+            const prices = data.items.map(item => item.price);
+            chartCaption.textContent = `Price history for ${symbol}`;
+            if (historyChart) {
+                historyChart.destroy();
+            }
+            historyChart = new Chart(chartCtx, {
+                type: 'line',
+                data: {
+                    labels,
+                    datasets: [{
+                        label: symbol,
+                        data: prices,
+                        tension: 0.3,
+                        borderColor: '#38bdf8',
+                        backgroundColor: 'rgba(56, 189, 248, 0.25)',
+                        fill: true,
+                        pointRadius: 0
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    scales: {
+                        x: { ticks: { color: '#94a3b8' } },
+                        y: { ticks: { color: '#94a3b8' } }
+                    },
+                    plugins: {
+                        legend: { labels: { color: '#e2e8f0' } },
+                        tooltip: { callbacks: { label: (ctx) => `Price: ${ctx.parsed.y}` } }
+                    }
+                }
+            });
+        }
+
+        async function bootstrap() {
+            await refreshStatus();
+            await refreshChanges();
+            setInterval(refreshStatus, 60000);
+            setInterval(refreshChanges, 120000);
+        }
+
+        bootstrap();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a configurable monitoring service that records screener snapshots, detects analyst rating changes, and persists them to SQLite
- expose a FastAPI app with REST endpoints, dashboard template, and Docker image for out-of-the-box deployment
- document the monitoring workflow and cover snapshot/rating change handling with unit tests

## Testing
- pytest tests/test_monitoring.py

------
https://chatgpt.com/codex/tasks/task_e_68ce7c7f591c8321a2ab8a952e199d85